### PR TITLE
adding elapsedMillis library

### DIFF
--- a/NXPMotionSense.cpp
+++ b/NXPMotionSense.cpp
@@ -1,6 +1,7 @@
 #include "NXPMotionSense.h"
 #include "utility/NXPSensorRegisters.h"
 #include <util/crc16.h>
+#include <elapsedMillis.h>
 
 #define NXP_MOTION_CAL_EEADDR  60
 #define NXP_MOTION_CAL_SIZE    68


### PR DESCRIPTION
I know this might not be the most elegent solution, i'm somewhat new to writing arduino libraries, but elapsedMicros and elapsedMillis are not in the Uno api by default, and this is the only way i've managed to get this library to work on an atmega328p. The library has to be installed and they need to be included manually, I do not have a teensy to verify weather or not this change would affect Teensy users, It would be very nice if there was a way to detect weather the target device is a teensy using a preprocessor config and only include the library if the device is not a teensy