### PR TITLE
Quaternion support for NXPSensorFusion, Orientation.ino and OrientationVisualiser.pde

### DIFF
--- a/NXPMotionSense.h
+++ b/NXPMotionSense.h
@@ -116,6 +116,7 @@ public:
 		float q2; // y
 		float q3; // z
 	} Quaternion_t;
+	Quaternion_t getQuaternion() { return qPl; }
 	// These are Madgwick & Mahony - extrinsic rotation reference (wrong!)
 	//float getPitch() {return atan2f(2.0f * qPl.q2 * qPl.q3 - 2.0f * qPl.q0 * qPl.q1, 2.0f * qPl.q0 * qPl.q0 + 2.0f * qPl.q3 * qPl.q3 - 1.0f);};
 	//float getRoll() {return -1.0f * asinf(2.0f * qPl.q1 * qPl.q3 + 2.0f * qPl.q0 * qPl.q2);};

--- a/examples/Orientation/Orientation.ino
+++ b/examples/Orientation/Orientation.ino
@@ -41,6 +41,17 @@ void loop() {
     Serial.print(pitch);
     Serial.print(" ");
     Serial.println(roll);
+
+    // Uncomment following lines to use internal quaternion for orientation (doesn't suffer from gimbal lock issues).
+    // NXPSensorFusion::Quaternion_t quaternion = filter.getQuaternion();
+    // Serial.print("Orientation: ");
+    // Serial.print(quaternion.q0, 5);
+    // Serial.print(" ");
+    // Serial.print(quaternion.q1, 5);
+    // Serial.print(" ");
+    // Serial.print(quaternion.q2, 5);
+    // Serial.print(" ");
+    // Serial.println(quaternion.q3, 5);
   }
 }
 


### PR DESCRIPTION
Hi Paul,

I extended NXPSensorFusion, Orientation.ino and OrientationVisualiser.pde so Teensy can use quaternion rotation in addition to traditional heading/pitch/roll.

The OrientationVisualiser will automatically detect which orientation data is used (should work with old Orientation.ino code as well).

Huge thanks for the original code and for the Teensy of course.