### PR TITLE
Altitude/Temp & Pressure made visible

### DIFF
--- a/NXPMotionSense.cpp
+++ b/NXPMotionSense.cpp
@@ -59,10 +59,10 @@ void NXPMotionSense::update()
 	if (FXOS8700_read(accel_mag_raw)) { // accel + mag
 		//Serial.println("accel+mag");
 	}
-	if (MPL3115_read(&alt, &temperature_raw)) { // alt
+	//if (MPL3115_read(&alt, &temperature_raw)) { // alt
 		//Serial.println("alt");
-		altimeter_rdy = 1;
-	} 
+	//	altimeter_rdy = 1;
+	//} 
 	if (FXAS21002_read(gyro_raw)) {  // gyro
 		//Serial.println("gyro");
 		newdata = 1;
@@ -239,21 +239,6 @@ bool NXPMotionSense::MPL3115_begin() // pressure
 	return true;
 }
 
-bool NXPMotionSense::MPL3115_read(int32_t *altitude, int16_t *temperature)
-{
-	//static elapsedMicros usec_since;
-	//static int32_t usec_history=980000;
-	const uint8_t i2c_addr=MPL3115_I2C_ADDR;
-	uint8_t buf[6];
-
-	readAltitude();
-
-	altimeter_rdy = 1;
-	//Serial.printf("%02X %d %d: ", buf[0], usec, usec_history);
-	//Serial.printf("%f,%f", altitudeM, tempC);
-	//Serial.println();
-	return true;
-}
 
 void NXPMotionSense::readAltitude()
 {

--- a/NXPMotionSense.cpp
+++ b/NXPMotionSense.cpp
@@ -59,9 +59,10 @@ void NXPMotionSense::update()
 	if (FXOS8700_read(accel_mag_raw)) { // accel + mag
 		//Serial.println("accel+mag");
 	}
-	if (MPL3115_read()) { // alt
+	if (MPL3115_read(&alt, &temperature_raw)) { // alt
 		//Serial.println("alt");
-	}
+		altimeter_rdy = 1;
+	} 
 	if (FXAS21002_read(gyro_raw)) {  // gyro
 		//Serial.println("gyro");
 		newdata = 1;
@@ -219,16 +220,26 @@ bool NXPMotionSense::FXAS21002_read(int16_t *data) // gyro
 
 bool NXPMotionSense::MPL3115_begin() // pressure
 {
-	MPL3115Reset();                // Start off by resetting all registers to the default
-	initRealTimeMPL3115();         // initialize the altimeter for realtime data acquisition if communication is OK
-	MPL3115SampleRate(SAMPLERATE); // Set oversampling ratio
-	MPL3115enableEventflags();     // Set data ready enable
-	delay (1000);
+        const uint8_t i2c_addr=MPL3115_I2C_ADDR;
+        uint8_t b;
+
+	if (!read_regs(i2c_addr, MPL3115_WHO_AM_I, &b, 1)) return false;
+	//Serial.printf("MPL3115 ID = %02X\n", b);
+	if (b != 0xC4) return false;
+
+	// place into standby mode
+	if (!write_reg(i2c_addr, MPL3115_CTRL_REG1, 0)) return false;
+
+	// switch to active, altimeter mode, 512 ms measurement, polling mode
+	if (!write_reg(i2c_addr, MPL3115_CTRL_REG1, 0xB9)) return false;
+	// enable events
+	if (!write_reg(i2c_addr, MPL3115_PT_DATA_CFG, 0x07)) return false;
+
 	//Serial.println("MPL3115 Configured");
 	return true;
 }
 
-bool NXPMotionSense::MPL3115_read()
+bool NXPMotionSense::MPL3115_read(int32_t *altitude, int16_t *temperature)
 {
 	static elapsedMicros usec_since;
 	static int32_t usec_history=980000;
@@ -238,7 +249,8 @@ bool NXPMotionSense::MPL3115_read()
 	int32_t usec = usec_since;
 	if (usec + 500 < usec_history) return false;
 
-	if (!read_regs(i2c_addr, FXAS21002_STATUS, buf, 1)) return false;
+	if (!read_regs(i2c_addr, FXAS21002_STATUS, buf, 1)) 
+		return false;
 	if (buf[0] == 0) return false;
 
 	if (!read_regs(i2c_addr, buf, 6)) return false;
@@ -248,34 +260,116 @@ bool NXPMotionSense::MPL3115_read()
 	if (diff < -1000) diff = -1000;
 	else if (diff > 1000) diff = 1000;
 	usec_history += diff;
-
-    MPL3115ActiveAltimeterMode(); 
-    MPL3115readAltitude();  // Read the altitude
-
-    MPL3115ActiveBarometerMode(); 
-    MPL3115readPressure();  // Read the pressure
-
-    const int station_elevation_m = def_sea_press*0.3048; // Accurate for the roof on my house; convert from feet to meters
-
-    float baroin = pressure/100; // pressure is now in millibars
-
-    // Formula to correct absolute pressure in millbars to "altimeter pressure" in inches of mercury 
-    // comparable to weather report pressure
-    float part1 = baroin - 0.3; //Part 1 of formula
-    const float part2 = 0.0000842288;
-    float part3 = pow(part1, 0.190284);
-    float part4 = (float)station_elevation_m / part3;
-    float part5 = (1.0 + (part2 * part4));
-    float part6 = pow(part5, 5.2553026);
-    altimeter_setting_pressure_mb = part1 * part6; // Output is now in adjusted millibars
-    baroin = altimeter_setting_pressure_mb * 0.02953;
 	
-	pressure = pressure/100.0;
+	//int32_t a = ((uint32_t)buf[1] << 12) | ((uint16_t)buf[2] << 4) | (buf[3] >> 4);
+	//if (a & 0x00080000) a |= 0xFFF00000;
+	//*altitude = a;
+	//*temperature = (int16_t)((buf[4] << 8) | buf[5]);
+	
+	// Calculate altitude, check for negative sign in altimeter data
+	long foo = 0;
+
+	if(buf[1] > 0x7F) {
+	   foo = ~((long)buf[1] << 16 | (long)buf[2] << 8 | (long)(buf[3]) + 1); // 2's complement the data
+	   altitudeM = (float) (foo >> 8) + (float)((buf[3] >> 4)/16.0); // Whole number plus fraction altitude in meters for negative altitude
+	   altitudeM *= -1.;
+	}
+	else {
+	   foo = ((buf[1] << 8) | buf[2]);
+	   altitudeM = (float) (foo) + (float) ((buf[3] >> 4)/16.0);  // Whole number plus fraction altitude in meters
+	}
+	 	
+	// Calculate temperature, check for negative sign
+	foo = 0;
+	if(buf[4] > 0x7F) {
+	 foo = ~(buf[4] << 8 | buf[5]) + 1 ; // 2's complement
+	 temperatureC = (float) (foo >> 8) + (float)((buf[5] >> 4)/16.0); // add whole and fractional degrees Centigrade
+	 temperatureC *= -1.;
+	 }
+	else {
+	   temperatureC = (float) (buf[4]) + (float)((buf[5] >> 4)/16.0); // add whole and fractional degrees Centigrade
+	}
+
+	altimeter_rdy = 1;
 	//Serial.printf("%02X %d %d: ", buf[0], usec, usec_history);
-	//Serial.printf("%2f,%2f, %2f", altitude, pressure, temperature);
+	//Serial.printf("%f,%f", altitudeM, tempC);
 	//Serial.println();
-	
 	return true;
+}
+
+void NXPMotionSense::readPressure()
+{
+	const uint8_t i2c_addr=MPL3115_I2C_ADDR;
+
+	//switch to pressure mode
+	// place into standby mode
+	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0);
+	// switch to active, altimeter mode, 512 ms measurement, polling mode
+	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0x39);
+	// enable events
+	write_reg(i2c_addr, MPL3115_PT_DATA_CFG, 0x07);
+
+	byte rawData[5];  // msb/csb/lsb pressure and msb/lsb temperature stored in five contiguous registers
+ 
+
+	while ((read_reg(MPL3115_I2C_ADDR, MPL3115_STATUS) & 0x08) == 0);  MPL3115_toggleOneShot(); 
+ 
+	read_regs(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB, &rawData[0], 5);  // Read the five raw data registers into data array
+
+	// Pressure bytes
+	byte msbP = rawData[0];
+	byte csbP = rawData[1];
+	byte lsbP = rawData[2];
+	// Temperature bytes
+	byte msbT = rawData[3];
+	byte lsbT = rawData[4]; 
+ 
+	long pressure_whole =   ((long)msbP << 16 |  (long)csbP << 8 |  (long)lsbP) ; // Construct whole number pressure
+	pressure_whole >>= 6; // Only two most significant bits of lsbP contribute to whole pressure; its an 18-bit number
+ 
+	lsbP &= 0x30; // Keep only bits 5 and 6, the fractional pressure
+	lsbP >>= 4; // Shift to get the fractional pressure in terms of quarters of a Pascal
+	float pressure_frac = (float) lsbP/4.0; // Convert numbers of fractional quarters to fractional pressure n Pasacl
+
+	pressure = (float) (pressure_whole) + pressure_frac; // Combine whole and fractional parts to get entire pressure in Pascal
+	pressure = pressure/100.0f;
+
+	//switch back to altimeter mode
+	// place into standby mode
+	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0);
+	// switch to active, altimeter mode, 512 ms measurement, polling mode
+	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0xB9);
+	// enable events
+	write_reg(i2c_addr, MPL3115_PT_DATA_CFG, 0x07);
+	
+}
+
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Clears then sets OST bit which causes the sensor to immediately take another reading
+void NXPMotionSense::MPL3115_toggleOneShot()
+{
+    //MPL3115_Active();  // Set to active to start reading
+    byte c;
+	read_regs(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, &c, 1);
+    write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c & ~(1<<1)); // Clear OST (bit 1)
+    read_regs(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, &c, 1);
+    write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c | (1<<1)); // Set OST bit to 1
+
+}
+
+/*!
+ *  @brief  Set the local sea level barometric pressure
+ *  @param pascal the pressure to use as the baseline
+ */
+
+void NXPMotionSense::setSeaPressure(float pascal) {
+  uint16_t bar = pascal / 2;
+  Wire.beginTransmission(MPL3115_I2C_ADDR);
+  Wire.write((uint8_t)MPL3115_BAR_IN_MSB);
+  Wire.write((uint8_t)(bar >> 8));
+  Wire.write((uint8_t)bar);
+  Wire.endTransmission(false);
 }
 
 bool NXPMotionSense::writeCalibration(const void *data)
@@ -300,294 +394,3 @@ bool NXPMotionSense::writeCalibration(const void *data)
 	return true;
 }
 
-
-//===================================================
-//MPL3115 Sensor Calls
-//===================================================
-void NXPMotionSense::MPL3115readAltitude() // Get altitude in meters and temperature in centigrade
-{
-  uint8_t rawData[5];  // msb/csb/lsb pressure and msb/lsb temperature stored in five contiguous registers 
-
-// We can read the data either by polling or interrupt; see data sheet for relative advantages
-// First we try hardware interrupt, which should take less power, etc.
-// while (digitalRead(INTP1) == LOW); // Wait for interrupt pin INTP1 to go HIGH
-// digitalWrite(INTP1, LOW);  // Reset interrupt pin INTP1
-// while((readByte(MPL3115A2_ADDRESS, MPL3115A2_INT_SOURCE) & 0x80) == 0); // Check that the interrupt source is a data ready interrupt
-// or use a polling method
-// Check data read status; if PTDR (bit 4) not set, then
-// toggle OST bit to cause sensor to immediately take a reading
-// Setting the one shot toggle is the way to get faster than 1 Hz data read rates
- while ((read_reg(MPL3115_I2C_ADDR, MPL3115_STATUS) & 0x08) == 0);  MPL3115toggleOneShot(); 
-  
-  read_regs(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB, &rawData[0], 5);  // Read the five raw data registers into data array
-
-// Altutude bytes-whole altitude contained defined by msb, csb, and first two bits of lsb, fraction by next two bits of lsb
-  uint8_t msbA = rawData[0];
-  uint8_t csbA = rawData[1];
-  uint8_t lsbA = rawData[2];
-// Temperature bytes
-  uint8_t msbT = rawData[3];
-  uint8_t lsbT = rawData[4];
- 
- // Calculate altitude, check for negative sign in altimeter data
- long foo = 0;
- if(msbA > 0x7F) {
-   foo = ~((long)msbA << 16 | (long)csbA << 8 | (long)lsbA) + 1; // 2's complement the data
-   altitude = (float) (foo >> 8) + (float) ((lsbA >> 4)/16.0); // Whole number plus fraction altitude in meters for negative altitude
-   altitude *= -1.;
- }
- else {
-   altitude = (float) ( (msbA << 8) | csbA) + (float) ((lsbA >> 4)/16.0);  // Whole number plus fraction altitude in meters
- }
-
- //Adafruit takes one more step:
- //altitude /= 65536.0;
- 
-// Calculate temperature, check for negative sign
-if(msbT > 0x7F) {
- foo = ~(msbT << 8 | lsbT) + 1 ; // 2's complement
- temperature = (float) (foo >> 8) + (float)((lsbT >> 4)/16.0); // add whole and fractional degrees Centigrade
- temperature *= -1.;
- }
- else {
-   temperature = (float) (msbT) + (float)((lsbT >> 4)/16.0); // add whole and fractional degrees Centigrade
- }
-}
-
-void NXPMotionSense::MPL3115readPressure()
-{
-  uint8_t  rawData[5];  // msb/csb/lsb pressure and msb/lsb temperature stored in five contiguous registers
-
-// We can read the data either by polling or interrupt; see data sheet for relative advantages
-// First we try hardware interrupt, which should take less power, etc.
-// while (digitalRead(int1Pin) == LOW); // Wait for interrupt pin int1Pin to go HIGH
-// digitalWrite(int1Pin, LOW);  // Reset interrupt pin int1Pin
-// while((readByte(MPL3115A2_ADDRESS, MPL3115A2_INT_SOURCE) & 0x80) == 0); // Check that the interrupt source is a data ready interrupt
-// or use a polling method
-// Check data read status; if PTDR (bit 4) not set, then
-// toggle OST bit to cause sensor to immediately take a reading
-// Setting the one shot toggle is the way to get faster than 1 Hz data read rates
- while ((read_reg(MPL3115_I2C_ADDR, MPL3115_STATUS) & 0x08) == 0); MPL3115toggleOneShot(); 
- 
-  read_regs(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB, &rawData[0], 5);  // Read the five raw data registers into data array
-
-// Pressure bytes
-  uint8_t msbP = rawData[0];
-  uint8_t csbP = rawData[1];
-  uint8_t lsbP = rawData[2];
-// Temperature bytes
-  uint8_t msbT = rawData[3];
-  uint8_t lsbT = rawData[4]; 
- 
-  long pressure_whole =   ((long)msbP << 16 |  (long)csbP << 8 |  (long)lsbP) ; // Construct whole number pressure
-  pressure_whole >>= 6; // Only two most significant bits of lsbP contribute to whole pressure; its an 18-bit number
- 
-  lsbP &= 0x30; // Keep only bits 5 and 6, the fractional pressure
-  lsbP >>= 4; // Shift to get the fractional pressure in terms of quarters of a Pascal
-  float pressure_frac = (float) lsbP/4.0; // Convert numbers of fractional quarters to fractional pressure n Pasacl
-
-  pressure = (float) (pressure_whole) + pressure_frac; // Combine whole and fractional parts to get entire pressure in Pascal
-
-// Calculate temperature, check for negative sign
-long foo = 0;
-if(msbT > 0x7F) { // Is the most significant bit a 1? Then its a negative number in two's complement form
- foo = ~((long) msbT << 8 | lsbT) + 1 ; // 2's complement
- temperature = (float) ((foo >> 8) + ((lsbT >> 4)/16.0)); // add whole and fractional degrees Centigrade
- temperature *= -1.;
- }
- else {
-   temperature = (float) (msbT) + (float)((lsbT >> 4)/16.0); // add whole and fractional degrees Centigrade
- }
-}
-
-/**
- * Sets sea level pressure
- * 
-*/
-void NXPMotionSense::setSeaPress(uint16_t sea_press_inp) {
-
-	def_sea_press = sea_press_inp;
-
-  uint16_t bar = sea_press_inp / 2;
-  Wire.beginTransmission(MPL3115_I2C_ADDR);
-  Wire.write((uint8_t)MPL3115_BAR_IN_MSB);
-  Wire.write((uint8_t)(bar >> 8));
-  Wire.write((uint8_t)bar);
-  Wire.endTransmission(false);
-}
-
-/*
-=====================================================================================================
-Define functions according to 
-"Data Manipulation and Basic Settings of the MPL3115 Command Line Interface Drive Code"
-by Miguel Salhuana
-Freescale Semiconductor Application Note AN4519 Rev 0.1, 08/2012
-=====================================================================================================
-*/
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// Clears then sets OST bit which causes the sensor to immediately take another reading
-void NXPMotionSense::MPL3115toggleOneShot()
-{
-    MPL3115Active();  // Set to active to start reading
-    uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1);
-    write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c & ~(1<<1)); // Clear OST (bit 1)
-    c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1);
-    write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c | (1<<1)); // Set OST bit to 1
-}
-    
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// Set the Outputting Sample Rate
-void NXPMotionSense::MPL3115SampleRate(uint8_t samplerate)
-{
-  MPL3115Standby();  // Must be in standby to change registers
-
-  uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1);
-  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c & ~(0x38)); // Clear OSR bits 3,4,5
-  if(samplerate < 8) { // OSR between 1 and 7
-  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c | (samplerate << 3));  // Write OSR to bits 3,4,5
-  }
-  
-  MPL3115Active();  // Set to active to start reading
- }
- 
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// Initialize the MPL3115 registers for FIFO mode
-void NXPMotionSense::initFIFOMPL3115()
-{
-  // Clear all interrupts by reading the data output registers
-  uint8_t temp;
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB);
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_CSB);
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_LSB);
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_T_MSB);
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_T_LSB);
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_F_STATUS);
-  
-   MPL3115Standby();  // Must be in standby to change registers
-  
-  // Set CTRL_REG4 register to configure interupt enable
-  // Enable data ready interrupt (bit 7), enable FIFO (bit 6), enable pressure window (bit 5), temperature window (bit 4),
-  // pressure threshold (bit 3), temperature threshold (bit 2), pressure change (bit 1) and temperature change (bit 0)
-  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG4, 0x40);  // enable FIFO
-  
-  //  Configure INT 1 for data ready, all other (inc. FIFO) interrupts to INT2
-  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG5, 0x80); 
-  
-  // Set CTRL_REG3 register to configure interupt signal type
-  // Active HIGH, push-pull interupts INT1 and INT 2
-  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG3, 0x22); 
-  
-  // Set FIFO mode
-  write_reg(MPL3115_I2C_ADDR, MPL3115_F_SETUP, 0x00); // Clear FIFO mode
-// In overflow mode, when FIFO fills up, no more data is taken until the FIFO registers are read
-// In watermark mode, the oldest data is overwritten by new data until the FIFO registers are read
-  write_reg(MPL3115_I2C_ADDR, MPL3115_F_SETUP, 0x80); // Set F_MODE to interrupt when overflow = 32 reached
-//  writeByte(MPL3115_I2C_ADDR, F_SETUP, 0x60); // Set F_MODE to accept 32 data samples and interrupt when watermark = 32 reached
-
-  MPL3115Active();  // Set to active to start reading
-}
-
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// Initialize the MPL3115 for realtime data collection 
-void NXPMotionSense::initRealTimeMPL3115()
-{
-  // Clear all interrupts by reading the data output registers
-  uint8_t temp;
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB);
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_CSB);
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_LSB);
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_T_MSB);
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_T_LSB);
-  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_F_STATUS);
-  
-   MPL3115Standby();  // Must be in standby to change registers
-  
-  // Set CTRL_REG4 register to configure interupt enable
-  // Enable data ready interrupt (bit 7), enable FIFO (bit 6), enable pressure window (bit 5), temperature window (bit 4),
-  // pressure threshold (bit 3), temperature threshold (bit 2), pressure change (bit 1) and temperature change (bit 0)
-  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG4, 0x80);  
-  
-  //  Configure INT 1 for data ready, all other interrupts to INT2
-  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG5, 0x80); 
-  
-  // Set CTRL_REG3 register to configure interupt signal type
-  // Active HIGH, push-pull interupts INT1 and INT 2
-  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG3, 0x22); 
-  
-  // Set FIFO mode
-  write_reg(MPL3115_I2C_ADDR, MPL3115_F_SETUP, 0x00); // disable FIFO mode
-  
-  MPL3115Active();  // Set to active to start reading
-}
-
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// Set the Auto Acquisition Time Step
-void NXPMotionSense::MPL3115TimeStep(uint8_t ST_Value)
-{
- MPL3115Standby(); // First put device in standby mode to allow write to registers
- 
- uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG2); // Read contents of register CTRL_REG2
- if (ST_Value <= 0xF) {
- write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG2, (c | ST_Value)); // Set time step n from 0x0 to 0xF (bits 0 - 3) for time intervals from 1 to 32768 (2^n) seconds
- }
- 
- MPL3115Active(); // Set to active to start reading
-}
-
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// Enable the pressure and temperature event flags
- // Bit 2 is general data ready event mode on new Pressure/Altitude or temperature data
- // Bit 1 is event flag on new Pressure/Altitude data
- // Bit 0 is event flag on new Temperature data
-void NXPMotionSense::MPL3115enableEventflags()
-{
-  MPL3115Standby();  // Must be in standby to change registers
-  write_reg(MPL3115_I2C_ADDR, MPL3115_PT_DATA_CFG, 0x07); //Enable all three pressure and temperature event flags
-  MPL3115Active();  // Set to active to start reading
-}
-
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// Enter Active Altimeter mode
-void NXPMotionSense::MPL3115ActiveAltimeterMode()
-{
- MPL3115Standby(); // First put device in standby mode to allow write to registers
- uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1); // Read contents of register CTRL_REG1
- write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c | (0x80)); // Set ALT (bit 7) to 1
- MPL3115Active(); // Set to active to start reading
-}
-
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// Enter Active Barometer mode
-void NXPMotionSense::MPL3115ActiveBarometerMode()
-{
- MPL3115Standby(); // First put device in standby mode to allow write to registers
- uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1); // Read contents of register CTRL_REG1
- write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c & ~(0x80)); // Set ALT (bit 7) to 0
- MPL3115Active(); // Set to active to start reading
-}
-
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// Software resets the MPL3115.
-// It must be in standby to change most register settings
-void NXPMotionSense::MPL3115Reset()
-{
-  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, 0x04); // Set RST (bit 2) to 1
-}
-
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// Sets the MPL3115 to standby mode.
-// It must be in standby to change most register settings
-void NXPMotionSense::MPL3115Standby()
-{
-  uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1); // Read contents of register CTRL_REG1
-  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c & ~(0x01)); // Set SBYB (bit 0) to 0
-}
-
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-// Sets the MPL3115 to active mode.
-// Needs to be in this mode to output data
-void NXPMotionSense::MPL3115Active()
-{
-  uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1); // Read contents of register CTRL_REG1
-  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c | 0x01); // Set SBYB (bit 0) to 1
-}

--- a/NXPMotionSense.cpp
+++ b/NXPMotionSense.cpp
@@ -59,7 +59,7 @@ void NXPMotionSense::update()
 	if (FXOS8700_read(accel_mag_raw)) { // accel + mag
 		//Serial.println("accel+mag");
 	}
-	if (MPL3115_read(&alt, &temperature_raw)) { // alt
+	if (MPL3115_read()) { // alt
 		//Serial.println("alt");
 	}
 	if (FXAS21002_read(gyro_raw)) {  // gyro
@@ -75,6 +75,19 @@ static bool write_reg(uint8_t i2c, uint8_t addr, uint8_t val)
 	Wire.write(addr);
 	Wire.write(val);
 	return Wire.endTransmission() == 0;
+}
+
+uint8_t read_reg(uint8_t address, uint8_t subAddress)
+{
+  uint8_t data; // `data` will store the register data   
+  Wire.beginTransmission(address);         // Initialize the Tx buffer
+  Wire.write(subAddress);                  // Put slave register address in Tx buffer
+  Wire.endTransmission(false);       // Send the Tx buffer, but send a restart to keep connection alive
+  delayMicroseconds(250);
+  //Wire.endTransmission(I2C_NOSTOP);        // Send the Tx buffer, but send a restart to keep connection alive
+  Wire.requestFrom(address, (size_t) 1);   // Read one byte from slave register address 
+  data = Wire.read();                      // Fill Rx buffer with result
+  return data;                             // Return data read from slave register
 }
 
 static bool read_regs(uint8_t i2c, uint8_t addr, uint8_t *data, uint8_t num)
@@ -206,26 +219,16 @@ bool NXPMotionSense::FXAS21002_read(int16_t *data) // gyro
 
 bool NXPMotionSense::MPL3115_begin() // pressure
 {
-        const uint8_t i2c_addr=MPL3115_I2C_ADDR;
-        uint8_t b;
-
-	if (!read_regs(i2c_addr, MPL3115_WHO_AM_I, &b, 1)) return false;
-	//Serial.printf("MPL3115 ID = %02X\n", b);
-	if (b != 0xC4) return false;
-
-	// place into standby mode
-	if (!write_reg(i2c_addr, MPL3115_CTRL_REG1, 0)) return false;
-
-	// switch to active, altimeter mode, 512 ms measurement, polling mode
-	if (!write_reg(i2c_addr, MPL3115_CTRL_REG1, 0xB9)) return false;
-	// enable events
-	if (!write_reg(i2c_addr, MPL3115_PT_DATA_CFG, 0x07)) return false;
-
+	MPL3115Reset();                // Start off by resetting all registers to the default
+	initRealTimeMPL3115();         // initialize the altimeter for realtime data acquisition if communication is OK
+	MPL3115SampleRate(SAMPLERATE); // Set oversampling ratio
+	MPL3115enableEventflags();     // Set data ready enable
+	delay (1000);
 	//Serial.println("MPL3115 Configured");
 	return true;
 }
 
-bool NXPMotionSense::MPL3115_read(int32_t *altitude, int16_t *temperature)
+bool NXPMotionSense::MPL3115_read()
 {
 	static elapsedMicros usec_since;
 	static int32_t usec_history=980000;
@@ -246,14 +249,32 @@ bool NXPMotionSense::MPL3115_read(int32_t *altitude, int16_t *temperature)
 	else if (diff > 1000) diff = 1000;
 	usec_history += diff;
 
-	int32_t a = ((uint32_t)buf[1] << 12) | ((uint16_t)buf[2] << 4) | (buf[3] >> 4);
-	if (a & 0x00080000) a |= 0xFFF00000;
-	*altitude = a;
-	*temperature = (int16_t)((buf[4] << 8) | buf[5]);
+    MPL3115ActiveAltimeterMode(); 
+    MPL3115readAltitude();  // Read the altitude
 
+    MPL3115ActiveBarometerMode(); 
+    MPL3115readPressure();  // Read the pressure
+
+    const int station_elevation_m = def_sea_press*0.3048; // Accurate for the roof on my house; convert from feet to meters
+
+    float baroin = pressure/100; // pressure is now in millibars
+
+    // Formula to correct absolute pressure in millbars to "altimeter pressure" in inches of mercury 
+    // comparable to weather report pressure
+    float part1 = baroin - 0.3; //Part 1 of formula
+    const float part2 = 0.0000842288;
+    float part3 = pow(part1, 0.190284);
+    float part4 = (float)station_elevation_m / part3;
+    float part5 = (1.0 + (part2 * part4));
+    float part6 = pow(part5, 5.2553026);
+    altimeter_setting_pressure_mb = part1 * part6; // Output is now in adjusted millibars
+    baroin = altimeter_setting_pressure_mb * 0.02953;
+	
+	pressure = pressure/100.0;
 	//Serial.printf("%02X %d %d: ", buf[0], usec, usec_history);
-	//Serial.printf("%6d,%6d", a, *temperature);
+	//Serial.printf("%2f,%2f, %2f", altitude, pressure, temperature);
 	//Serial.println();
+	
 	return true;
 }
 
@@ -279,3 +300,294 @@ bool NXPMotionSense::writeCalibration(const void *data)
 	return true;
 }
 
+
+//===================================================
+//MPL3115 Sensor Calls
+//===================================================
+void NXPMotionSense::MPL3115readAltitude() // Get altitude in meters and temperature in centigrade
+{
+  uint8_t rawData[5];  // msb/csb/lsb pressure and msb/lsb temperature stored in five contiguous registers 
+
+// We can read the data either by polling or interrupt; see data sheet for relative advantages
+// First we try hardware interrupt, which should take less power, etc.
+// while (digitalRead(INTP1) == LOW); // Wait for interrupt pin INTP1 to go HIGH
+// digitalWrite(INTP1, LOW);  // Reset interrupt pin INTP1
+// while((readByte(MPL3115A2_ADDRESS, MPL3115A2_INT_SOURCE) & 0x80) == 0); // Check that the interrupt source is a data ready interrupt
+// or use a polling method
+// Check data read status; if PTDR (bit 4) not set, then
+// toggle OST bit to cause sensor to immediately take a reading
+// Setting the one shot toggle is the way to get faster than 1 Hz data read rates
+ while ((read_reg(MPL3115_I2C_ADDR, MPL3115_STATUS) & 0x08) == 0);  MPL3115toggleOneShot(); 
+  
+  read_regs(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB, &rawData[0], 5);  // Read the five raw data registers into data array
+
+// Altutude bytes-whole altitude contained defined by msb, csb, and first two bits of lsb, fraction by next two bits of lsb
+  uint8_t msbA = rawData[0];
+  uint8_t csbA = rawData[1];
+  uint8_t lsbA = rawData[2];
+// Temperature bytes
+  uint8_t msbT = rawData[3];
+  uint8_t lsbT = rawData[4];
+ 
+ // Calculate altitude, check for negative sign in altimeter data
+ long foo = 0;
+ if(msbA > 0x7F) {
+   foo = ~((long)msbA << 16 | (long)csbA << 8 | (long)lsbA) + 1; // 2's complement the data
+   altitude = (float) (foo >> 8) + (float) ((lsbA >> 4)/16.0); // Whole number plus fraction altitude in meters for negative altitude
+   altitude *= -1.;
+ }
+ else {
+   altitude = (float) ( (msbA << 8) | csbA) + (float) ((lsbA >> 4)/16.0);  // Whole number plus fraction altitude in meters
+ }
+
+ //Adafruit takes one more step:
+ //altitude /= 65536.0;
+ 
+// Calculate temperature, check for negative sign
+if(msbT > 0x7F) {
+ foo = ~(msbT << 8 | lsbT) + 1 ; // 2's complement
+ temperature = (float) (foo >> 8) + (float)((lsbT >> 4)/16.0); // add whole and fractional degrees Centigrade
+ temperature *= -1.;
+ }
+ else {
+   temperature = (float) (msbT) + (float)((lsbT >> 4)/16.0); // add whole and fractional degrees Centigrade
+ }
+}
+
+void NXPMotionSense::MPL3115readPressure()
+{
+  uint8_t  rawData[5];  // msb/csb/lsb pressure and msb/lsb temperature stored in five contiguous registers
+
+// We can read the data either by polling or interrupt; see data sheet for relative advantages
+// First we try hardware interrupt, which should take less power, etc.
+// while (digitalRead(int1Pin) == LOW); // Wait for interrupt pin int1Pin to go HIGH
+// digitalWrite(int1Pin, LOW);  // Reset interrupt pin int1Pin
+// while((readByte(MPL3115A2_ADDRESS, MPL3115A2_INT_SOURCE) & 0x80) == 0); // Check that the interrupt source is a data ready interrupt
+// or use a polling method
+// Check data read status; if PTDR (bit 4) not set, then
+// toggle OST bit to cause sensor to immediately take a reading
+// Setting the one shot toggle is the way to get faster than 1 Hz data read rates
+ while ((read_reg(MPL3115_I2C_ADDR, MPL3115_STATUS) & 0x08) == 0); MPL3115toggleOneShot(); 
+ 
+  read_regs(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB, &rawData[0], 5);  // Read the five raw data registers into data array
+
+// Pressure bytes
+  uint8_t msbP = rawData[0];
+  uint8_t csbP = rawData[1];
+  uint8_t lsbP = rawData[2];
+// Temperature bytes
+  uint8_t msbT = rawData[3];
+  uint8_t lsbT = rawData[4]; 
+ 
+  long pressure_whole =   ((long)msbP << 16 |  (long)csbP << 8 |  (long)lsbP) ; // Construct whole number pressure
+  pressure_whole >>= 6; // Only two most significant bits of lsbP contribute to whole pressure; its an 18-bit number
+ 
+  lsbP &= 0x30; // Keep only bits 5 and 6, the fractional pressure
+  lsbP >>= 4; // Shift to get the fractional pressure in terms of quarters of a Pascal
+  float pressure_frac = (float) lsbP/4.0; // Convert numbers of fractional quarters to fractional pressure n Pasacl
+
+  pressure = (float) (pressure_whole) + pressure_frac; // Combine whole and fractional parts to get entire pressure in Pascal
+
+// Calculate temperature, check for negative sign
+long foo = 0;
+if(msbT > 0x7F) { // Is the most significant bit a 1? Then its a negative number in two's complement form
+ foo = ~((long) msbT << 8 | lsbT) + 1 ; // 2's complement
+ temperature = (float) ((foo >> 8) + ((lsbT >> 4)/16.0)); // add whole and fractional degrees Centigrade
+ temperature *= -1.;
+ }
+ else {
+   temperature = (float) (msbT) + (float)((lsbT >> 4)/16.0); // add whole and fractional degrees Centigrade
+ }
+}
+
+/**
+ * Sets sea level pressure
+ * 
+*/
+void NXPMotionSense::setSeaPress(uint16_t sea_press_inp) {
+
+	def_sea_press = sea_press_inp;
+
+  uint16_t bar = sea_press_inp / 2;
+  Wire.beginTransmission(MPL3115_I2C_ADDR);
+  Wire.write((uint8_t)MPL3115_BAR_IN_MSB);
+  Wire.write((uint8_t)(bar >> 8));
+  Wire.write((uint8_t)bar);
+  Wire.endTransmission(false);
+}
+
+/*
+=====================================================================================================
+Define functions according to 
+"Data Manipulation and Basic Settings of the MPL3115 Command Line Interface Drive Code"
+by Miguel Salhuana
+Freescale Semiconductor Application Note AN4519 Rev 0.1, 08/2012
+=====================================================================================================
+*/
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Clears then sets OST bit which causes the sensor to immediately take another reading
+void NXPMotionSense::MPL3115toggleOneShot()
+{
+    MPL3115Active();  // Set to active to start reading
+    uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1);
+    write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c & ~(1<<1)); // Clear OST (bit 1)
+    c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1);
+    write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c | (1<<1)); // Set OST bit to 1
+}
+    
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Set the Outputting Sample Rate
+void NXPMotionSense::MPL3115SampleRate(uint8_t samplerate)
+{
+  MPL3115Standby();  // Must be in standby to change registers
+
+  uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1);
+  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c & ~(0x38)); // Clear OSR bits 3,4,5
+  if(samplerate < 8) { // OSR between 1 and 7
+  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c | (samplerate << 3));  // Write OSR to bits 3,4,5
+  }
+  
+  MPL3115Active();  // Set to active to start reading
+ }
+ 
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Initialize the MPL3115 registers for FIFO mode
+void NXPMotionSense::initFIFOMPL3115()
+{
+  // Clear all interrupts by reading the data output registers
+  uint8_t temp;
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB);
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_CSB);
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_LSB);
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_T_MSB);
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_T_LSB);
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_F_STATUS);
+  
+   MPL3115Standby();  // Must be in standby to change registers
+  
+  // Set CTRL_REG4 register to configure interupt enable
+  // Enable data ready interrupt (bit 7), enable FIFO (bit 6), enable pressure window (bit 5), temperature window (bit 4),
+  // pressure threshold (bit 3), temperature threshold (bit 2), pressure change (bit 1) and temperature change (bit 0)
+  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG4, 0x40);  // enable FIFO
+  
+  //  Configure INT 1 for data ready, all other (inc. FIFO) interrupts to INT2
+  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG5, 0x80); 
+  
+  // Set CTRL_REG3 register to configure interupt signal type
+  // Active HIGH, push-pull interupts INT1 and INT 2
+  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG3, 0x22); 
+  
+  // Set FIFO mode
+  write_reg(MPL3115_I2C_ADDR, MPL3115_F_SETUP, 0x00); // Clear FIFO mode
+// In overflow mode, when FIFO fills up, no more data is taken until the FIFO registers are read
+// In watermark mode, the oldest data is overwritten by new data until the FIFO registers are read
+  write_reg(MPL3115_I2C_ADDR, MPL3115_F_SETUP, 0x80); // Set F_MODE to interrupt when overflow = 32 reached
+//  writeByte(MPL3115_I2C_ADDR, F_SETUP, 0x60); // Set F_MODE to accept 32 data samples and interrupt when watermark = 32 reached
+
+  MPL3115Active();  // Set to active to start reading
+}
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Initialize the MPL3115 for realtime data collection 
+void NXPMotionSense::initRealTimeMPL3115()
+{
+  // Clear all interrupts by reading the data output registers
+  uint8_t temp;
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB);
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_CSB);
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_P_LSB);
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_T_MSB);
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_OUT_T_LSB);
+  temp = read_reg(MPL3115_I2C_ADDR, MPL3115_F_STATUS);
+  
+   MPL3115Standby();  // Must be in standby to change registers
+  
+  // Set CTRL_REG4 register to configure interupt enable
+  // Enable data ready interrupt (bit 7), enable FIFO (bit 6), enable pressure window (bit 5), temperature window (bit 4),
+  // pressure threshold (bit 3), temperature threshold (bit 2), pressure change (bit 1) and temperature change (bit 0)
+  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG4, 0x80);  
+  
+  //  Configure INT 1 for data ready, all other interrupts to INT2
+  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG5, 0x80); 
+  
+  // Set CTRL_REG3 register to configure interupt signal type
+  // Active HIGH, push-pull interupts INT1 and INT 2
+  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG3, 0x22); 
+  
+  // Set FIFO mode
+  write_reg(MPL3115_I2C_ADDR, MPL3115_F_SETUP, 0x00); // disable FIFO mode
+  
+  MPL3115Active();  // Set to active to start reading
+}
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Set the Auto Acquisition Time Step
+void NXPMotionSense::MPL3115TimeStep(uint8_t ST_Value)
+{
+ MPL3115Standby(); // First put device in standby mode to allow write to registers
+ 
+ uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG2); // Read contents of register CTRL_REG2
+ if (ST_Value <= 0xF) {
+ write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG2, (c | ST_Value)); // Set time step n from 0x0 to 0xF (bits 0 - 3) for time intervals from 1 to 32768 (2^n) seconds
+ }
+ 
+ MPL3115Active(); // Set to active to start reading
+}
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Enable the pressure and temperature event flags
+ // Bit 2 is general data ready event mode on new Pressure/Altitude or temperature data
+ // Bit 1 is event flag on new Pressure/Altitude data
+ // Bit 0 is event flag on new Temperature data
+void NXPMotionSense::MPL3115enableEventflags()
+{
+  MPL3115Standby();  // Must be in standby to change registers
+  write_reg(MPL3115_I2C_ADDR, MPL3115_PT_DATA_CFG, 0x07); //Enable all three pressure and temperature event flags
+  MPL3115Active();  // Set to active to start reading
+}
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Enter Active Altimeter mode
+void NXPMotionSense::MPL3115ActiveAltimeterMode()
+{
+ MPL3115Standby(); // First put device in standby mode to allow write to registers
+ uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1); // Read contents of register CTRL_REG1
+ write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c | (0x80)); // Set ALT (bit 7) to 1
+ MPL3115Active(); // Set to active to start reading
+}
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Enter Active Barometer mode
+void NXPMotionSense::MPL3115ActiveBarometerMode()
+{
+ MPL3115Standby(); // First put device in standby mode to allow write to registers
+ uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1); // Read contents of register CTRL_REG1
+ write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c & ~(0x80)); // Set ALT (bit 7) to 0
+ MPL3115Active(); // Set to active to start reading
+}
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Software resets the MPL3115.
+// It must be in standby to change most register settings
+void NXPMotionSense::MPL3115Reset()
+{
+  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, 0x04); // Set RST (bit 2) to 1
+}
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Sets the MPL3115 to standby mode.
+// It must be in standby to change most register settings
+void NXPMotionSense::MPL3115Standby()
+{
+  uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1); // Read contents of register CTRL_REG1
+  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c & ~(0x01)); // Set SBYB (bit 0) to 0
+}
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Sets the MPL3115 to active mode.
+// Needs to be in this mode to output data
+void NXPMotionSense::MPL3115Active()
+{
+  uint8_t c = read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1); // Read contents of register CTRL_REG1
+  write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, c | 0x01); // Set SBYB (bit 0) to 1
+}

--- a/NXPMotionSense.h
+++ b/NXPMotionSense.h
@@ -89,6 +89,7 @@ public:
 	
 	void setSeaPressure(float pascal);
 	void readPressure();
+	void readAltitude();
 	float altitudeM, temperatureC, pressure;
 	uint8_t altimeter_rdy = 0;
 	

--- a/NXPMotionSense.h
+++ b/NXPMotionSense.h
@@ -91,7 +91,6 @@ public:
 	void readPressure();
 	void readAltitude();
 	float altitudeM, temperatureC, pressure;
-	uint8_t altimeter_rdy = 0;
 	
 private:
 	void update();
@@ -100,7 +99,6 @@ private:
 	bool MPL3115_begin();
 	bool FXOS8700_read(int16_t *data);
 	bool FXAS21002_read(int16_t *data);
-	bool MPL3115_read(int32_t *altitude, int16_t *temperature);
 	void MPL3115_toggleOneShot();
 	
 	float cal[16]; // 0-8=offsets, 9=field strength, 10-15=soft iron map

--- a/examples/Attitude_AltitudeData/Attitude_AltitudeData.ino
+++ b/examples/Attitude_AltitudeData/Attitude_AltitudeData.ino
@@ -1,0 +1,61 @@
+// Full orientation sensing using NXP's advanced sensor fusion algorithm.
+//
+// You *must* perform a magnetic calibration before this code will work.
+//
+// To view this data, use the Arduino Serial Monitor to watch the
+// scrolling angles, or run the OrientationVisualiser example in Processing.
+
+#include <NXPMotionSense.h>
+#include <Wire.h>
+#include <EEPROM.h>
+
+NXPMotionSense imu;
+NXPSensorFusion filter;
+
+elapsedMillis MPL = 0;
+
+void setup() {
+  Serial.begin(9600);
+  imu.begin();
+  filter.begin(100);
+
+  //sets local sea level pressure
+  //you can get this from your closest airport from
+  //     https://aviationweather.gov/metar
+  imu.setSeaPressure(102100);
+}
+
+void loop() {
+  float ax, ay, az;
+  float gx, gy, gz;
+  float mx, my, mz;
+  float roll, pitch, heading;
+
+  if (imu.available()) {
+    // Read the motion sensors
+    imu.readMotionSensor(ax, ay, az, gx, gy, gz, mx, my, mz);
+
+    // Update the SensorFusion filter
+    filter.update(gx, gy, gz, ax, ay, az, mx, my, mz);
+
+    // print the heading, pitch and roll
+    roll = filter.getRoll();
+    pitch = filter.getPitch();
+    heading = filter.getYaw();
+    Serial.print("Orientation: ");
+    Serial.print(heading);
+    Serial.print(" ");
+    Serial.print(pitch);
+    Serial.print(" ");
+    Serial.println(roll);
+    if(MPL > 100){
+      //reading pressure causes a noticable delay as a result of
+      //switching between altimeter and barometer modes of the
+      //MPL3115.
+      imu.readAltitude();
+      imu.readPressure();
+      MPL = 0;
+      Serial.printf("Alt: %f, TempC: %f, Press: %f\n", imu.altitudeM, imu.temperatureC, imu.pressure);
+    }
+  }
+}

--- a/utility/NXPSensorRegisters.h
+++ b/utility/NXPSensorRegisters.h
@@ -145,7 +145,7 @@
 
 #define MPL3115_I2C_ADDR             0x60 // fixed I2C address
 #define MPL3115_STATUS               0x00 // Sensor Status Register
-#define MPL3115_OUT P_MSB            0x01 // Pressure Data Out MSB
+#define MPL3115_OUT_P_MSB            0x01 // Pressure Data Out MSB
 #define MPL3115_OUT_P_CSB            0x02 // Pressure Data Out CSB
 #define MPL3115_OUT_P_LSB            0x03 // Pressure Data Out LSB
 #define MPL3115_OUT_T_MSB            0x04 // Temperature Data Out MSB


### PR DESCRIPTION
Hi Paul

In the thread, https://forum.pjrc.com/threads/40346-Teensy-3-2-w-Prop-Shield-Pressure-Sensor-causing-sketch-to-run-very-slow, and one of the Issues some folks wanted to make data from the MPL sensor visible to the user and improve speed.

I made some changes, but not sure best, that reduces the Over Sample rate down to 32ms from 512ms that you currently use.  In addition I added three functions:
```
	void setSeaPressure(float pascal);   // allows user to set local sea level pressure
	void readPressure();  // reads pressure in millibars
	void readAltitude();  // reads altitude in meters and temperature in degrees centigrade
```

readPressure and readAltitude functions lifted from Kris Winers MPL3115A2 code.  setSeaPressure from adafruit library since it was already there (just sets a register). 

So now if a user wants MPL data they have to specifically ask for it so I removed the MPL3115_read call in the Update function.  The code defaults to altimeter mode.  When you call readPressure it switches to barometer mode and then back to altimeter mode.  I also added a an example.

Let me know if you want anything changed.