### PR TITLE
Faster baro reads, new example and modified visualizer was added

### DIFF
--- a/NXPMotionSense.cpp
+++ b/NXPMotionSense.cpp
@@ -59,9 +59,9 @@ void NXPMotionSense::update()
 	if (FXOS8700_read(accel_mag_raw)) { // accel + mag
 		//Serial.println("accel+mag");
 	}
-	if (MPL3115_read(&alt, &temperature_raw)) { // alt
+	//if (MPL3115_read(&alt, &temperature_raw)) { // alt
 		//Serial.println("alt");
-	}
+	//}
 	if (FXAS21002_read(gyro_raw)) {  // gyro
 		//Serial.println("gyro");
 		newdata = 1;

--- a/NXPMotionSense.cpp
+++ b/NXPMotionSense.cpp
@@ -54,12 +54,12 @@ bool NXPMotionSense::begin()
 void NXPMotionSense::update()
 {
 	static elapsedMillis msec;
-	int32_t alt;
+	//int32_t alt;
 
 	if (FXOS8700_read(accel_mag_raw)) { // accel + mag
 		//Serial.println("accel+mag");
 	}
-	if (MPL3115_read(&alt, &temperature_raw)) { // alt
+	//if (MPL3115_read(&alt, &temperature_raw)) { // alt
 		//Serial.println("alt");
 	}
 	if (FXAS21002_read(gyro_raw)) {  // gyro
@@ -77,22 +77,26 @@ static bool write_reg(uint8_t i2c, uint8_t addr, uint8_t val)
 	return Wire.endTransmission() == 0;
 }
 
+uint8_t read_reg(uint8_t address, uint8_t subAddress) 
+{
+  	uint8_t data;                    // `data` will store the register data
+  	Wire.beginTransmission(address); // Initialize the Tx buffer
+  	Wire.write(subAddress);          // Put slave register address in Tx buffer
+  	Wire.endTransmission(false); // Send the Tx buffer, but send a restart to keep connection alive
+  	delayMicroseconds(250);
+  	// Wire.endTransmission(I2C_NOSTOP);        // Send the Tx buffer, but send a
+  	// restart to keep connection alive
+  	Wire.requestFrom(address,
+                   (size_t)1); // Read one byte from slave register address
+  	data = Wire.read();          // Fill Rx buffer with result
+  	return data;                 // Return data read from slave register
+}
+
 static bool read_regs(uint8_t i2c, uint8_t addr, uint8_t *data, uint8_t num)
 {
 	Wire.beginTransmission(i2c);
 	Wire.write(addr);
 	if (Wire.endTransmission(false) != 0) return false;
-	Wire.requestFrom(i2c, num);
-	if (Wire.available() != num) return false;
-	while (num > 0) {
-		*data++ = Wire.read();
-		num--;
-	}
-	return true;
-}
-
-static bool read_regs(uint8_t i2c, uint8_t *data, uint8_t num)
-{
 	Wire.requestFrom(i2c, num);
 	if (Wire.available() != num) return false;
 	while (num > 0) {
@@ -225,37 +229,181 @@ bool NXPMotionSense::MPL3115_begin() // pressure
 	return true;
 }
 
-bool NXPMotionSense::MPL3115_read(int32_t *altitude, int16_t *temperature)
-{
-	static elapsedMicros usec_since;
-	static int32_t usec_history=980000;
-	const uint8_t i2c_addr=MPL3115_I2C_ADDR;
-	uint8_t buf[6];
-
-	int32_t usec = usec_since;
-	if (usec + 500 < usec_history) return false;
-
-	if (!read_regs(i2c_addr, FXAS21002_STATUS, buf, 1)) return false;
-	if (buf[0] == 0) return false;
-
-	if (!read_regs(i2c_addr, buf, 6)) return false;
-
-	usec_since -= usec;
-	int diff = (usec - usec_history) >> 3;
-	if (diff < -1000) diff = -1000;
-	else if (diff > 1000) diff = 1000;
-	usec_history += diff;
-
-	int32_t a = ((uint32_t)buf[1] << 12) | ((uint16_t)buf[2] << 4) | (buf[3] >> 4);
-	if (a & 0x00080000) a |= 0xFFF00000;
-	*altitude = a;
-	*temperature = (int16_t)((buf[4] << 8) | buf[5]);
-
-	//Serial.printf("%02X %d %d: ", buf[0], usec, usec_history);
-	//Serial.printf("%6d,%6d", a, *temperature);
-	//Serial.println();
-	return true;
+void NXPMotionSense::readAltitude() //simplest way to get altitude
+{  
+  	// but slower. Does nothing while waiting for results from toggleOneShot readings from baro
+  	MPL3115_toggleOneShot();  //starts altitude calcs on baro
+  	readOneShotAlt();	    //gets alt and temperature results from baro
 }
+
+void NXPMotionSense::readOneShotAlt() //gets alt and temp results from baro
+{ 
+  	//after readAltitude()
+  	// or can be used after MPL3115_toggleOneShot() has been called for in your .ino
+
+  	uint8_t rawData[5]; // msb/csb/lsb pressure and msb/lsb temperature stored in
+                      // five contiguous registers
+  	// when below == 1: A new set of data is ready
+  	while ((read_reg(MPL3115_I2C_ADDR, MPL3115_STATUS) & 0x08) == 0);
+
+
+  	read_regs(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB, &rawData[0],
+            5); // Read the five raw data registers into data array
+
+  	// Altutude bytes-whole altitude contained defined by msb, csb, and first two
+  	// bits of lsb, fraction by next two bits of lsb
+  	uint8_t msbA = rawData[0];
+  	uint8_t csbA = rawData[1];
+  	uint8_t lsbA = rawData[2];
+  	// Temperature bytes
+  	uint8_t msbT = rawData[3];
+  	uint8_t lsbT = rawData[4];
+
+  	// Calculate altitude, check for negative sign in altimeter data
+  	long foo = 0;
+  	if (msbA > 0x7F) {
+  	  foo = ~((long)msbA << 16 | (long)csbA << 8 | (long)lsbA) +
+            	1; // 2's complement the data
+    	  altitudeM =
+        	(float)(foo >> 8) +
+        	(float)((lsbA >> 4) / 16.0); // Whole number plus fraction altitude in
+                                     // meters for negative altitude
+    	  altitudeM *= -1.;
+  	} else {
+    	  altitudeM = (float)((msbA << 8) | csbA) +
+                (float)((lsbA >> 4) /
+                        16.0); // Whole number plus fraction altitude in meters
+  	}
+
+  	// Calculate temperature, check for negative sign
+  	if (msbT > 0x7F) {
+    		foo = ~(msbT << 8 | lsbT) + 1; // 2's complement
+    		temperatureC = (float)(foo >> 8) +
+                   (float)((lsbT >> 4) /
+                           16.0); // add whole and fractional degrees Centigrade
+    		temperatureC *= -1.;
+  	} else {
+    		temperatureC = (float)(msbT) +
+                   (float)((lsbT >> 4) /
+                           16.0); // add whole and fractional degrees Centigrade
+  	}
+}
+
+void NXPMotionSense::readPressure() {
+  	const uint8_t i2c_addr = MPL3115_I2C_ADDR;
+
+  	// switch to pressure mode
+  	//  place into standby mode
+  	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0);
+  	// switch to active, altimeter mode, 32 ms measurement, polling mode
+  	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0x29);
+  	// enable events
+  	write_reg(i2c_addr, MPL3115_PT_DATA_CFG, 0x07);
+
+  	byte rawData[5]; // msb/csb/lsb pressure and msb/lsb temperature stored in
+                   // five contiguous registers
+
+  	while ((read_reg(MPL3115_I2C_ADDR, MPL3115_STATUS) & 0x08) == 0);
+  	MPL3115_toggleOneShot();
+
+  	read_regs(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB, &rawData[0],
+            5); // Read the five raw data registers into data array
+
+  	// Pressure bytes
+  	uint8_t msbP = rawData[0];
+  	uint8_t csbP = rawData[1];
+  	uint8_t lsbP = rawData[2];
+  	// Temperature bytes
+  	uint8_t msbT = rawData[3];
+  	uint8_t lsbT = rawData[4];
+
+  	long pressure_whole = ((long)msbP << 16 | (long)csbP << 8 |
+        	(long)lsbP); // Construct whole number pressure
+  	pressure_whole >>= 6; // Only two most significant bits of lsbP contribute to
+                        // whole pressure; its an 18-bit number
+
+  	lsbP &= 0x30; // Keep only bits 5 and 6, the fractional pressure
+  	lsbP >>= 4; // Shift to get the fractional pressure in terms of quarters of a
+              // Pascal
+  	float pressure_frac =
+      		(float)lsbP / 4.0; // Convert numbers of fractional quarters to fractional
+                         // pressure n Pasacl
+
+  	pressure = (float)(pressure_whole) +
+        	pressure_frac; // Combine whole and fractional parts to get entire
+                            // pressure in Pascal
+  	pressure = pressure / 100.0f;
+
+  	// Calculate temperature, check for negative sign
+  	long foo = 0;
+  	if (msbT > 0x7F) {
+  		foo = ~(msbT << 8 | lsbT) + 1; // 2's complement
+    	temperatureC = (float)(foo >> 8) +
+        	(float)((lsbT >> 4) /
+                	16.0); // add whole and fractional degrees Centigrade
+    	temperatureC *= -1.;
+  	} else {
+    		temperatureC = (float)(msbT) +
+                	(float)((lsbT >> 4) /
+                        	16.0); // add whole and fractional degrees Centigrade
+  	}
+
+  	// switch back to altimeter mode
+  	//  place into standby mode
+  	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0);
+  	// switch to active, altimeter mode, 10 ms measurement, polling mode
+  	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0x89);
+  	// enable events
+  	write_reg(i2c_addr, MPL3115_PT_DATA_CFG, 0x07);
+}
+
+	/*!
+	 *  @brief Set the oversample rate
+	 *  @param sampleRate oversample rate from 0 to 7
+	 * The higher the oversample rate the more time between samples
+	 */
+void NXPMotionSense::setOversampleRate(int8_t sampleRate) 
+{
+	if (sampleRate > 7)
+	sampleRate = 7; // OS cannot be larger than 0b.0111
+	sampleRate <<= 3; // Align it for the CTRL_REG1 register
+
+  	int8_t tempSetting =
+	read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1); // Read current settings
+	tempSetting &= 0xc7;       // B11000111; //Clear out old OS bits
+	tempSetting |= sampleRate; // Mask in new OS bits
+	write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, tempSetting);
+}
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Clears then sets OST bit which causes the sensor to immediately take another
+// reading
+void NXPMotionSense::MPL3115_toggleOneShot() 
+{
+  	// MPL3115_Active();  // Set to active to start reading
+  	byte c;
+  	read_regs(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, &c, 1);
+  	write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1,
+            c & ~(1 << 1)); // Clear OST (bit 1)
+  	read_regs(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, &c, 1);
+  	write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1,
+            c | (1 << 1)); // Set OST bit to 1
+}
+
+	/*!
+	 *  @brief  Set the local sea level barometric pressure
+	 *  @param pascal the pressure to use as the baseline
+	 */
+
+void NXPMotionSense::setSeaPressure(float pascal) 
+{
+  	uint16_t bar = pascal / 2;
+  	Wire.beginTransmission(MPL3115_I2C_ADDR);
+  	Wire.write((uint8_t)MPL3115_BAR_IN_MSB);
+  	Wire.write((uint8_t)(bar >> 8));
+  	Wire.write((uint8_t)bar);
+  	Wire.endTransmission(false);
+}	
 
 bool NXPMotionSense::writeCalibration(const void *data)
 {

--- a/NXPMotionSense.cpp
+++ b/NXPMotionSense.cpp
@@ -59,7 +59,7 @@ void NXPMotionSense::update()
 	if (FXOS8700_read(accel_mag_raw)) { // accel + mag
 		//Serial.println("accel+mag");
 	}
-	//if (MPL3115_read(&alt, &temperature_raw)) { // alt
+	if (MPL3115_read(&alt, &temperature_raw)) { // alt
 		//Serial.println("alt");
 	}
 	if (FXAS21002_read(gyro_raw)) {  // gyro

--- a/NXPMotionSense.cpp
+++ b/NXPMotionSense.cpp
@@ -54,14 +54,14 @@ bool NXPMotionSense::begin()
 void NXPMotionSense::update()
 {
 	static elapsedMillis msec;
-	int32_t alt;
+	//int32_t alt;
 
 	if (FXOS8700_read(accel_mag_raw)) { // accel + mag
 		//Serial.println("accel+mag");
 	}
-	if (MPL3115_read(&alt, &temperature_raw)) { // alt
+	//if (MPL3115_read(&alt, &temperature_raw)) { // alt
 		//Serial.println("alt");
-	}
+	//}
 	if (FXAS21002_read(gyro_raw)) {  // gyro
 		//Serial.println("gyro");
 		newdata = 1;
@@ -77,22 +77,26 @@ static bool write_reg(uint8_t i2c, uint8_t addr, uint8_t val)
 	return Wire.endTransmission() == 0;
 }
 
+uint8_t read_reg(uint8_t address, uint8_t subAddress) 
+{
+  	uint8_t data;                    // `data` will store the register data
+  	Wire.beginTransmission(address); // Initialize the Tx buffer
+  	Wire.write(subAddress);          // Put slave register address in Tx buffer
+  	Wire.endTransmission(false); // Send the Tx buffer, but send a restart to keep connection alive
+  	delayMicroseconds(250);
+  	// Wire.endTransmission(I2C_NOSTOP);        // Send the Tx buffer, but send a
+  	// restart to keep connection alive
+  	Wire.requestFrom(address,
+                   (size_t)1); // Read one byte from slave register address
+  	data = Wire.read();          // Fill Rx buffer with result
+  	return data;                 // Return data read from slave register
+}
+
 static bool read_regs(uint8_t i2c, uint8_t addr, uint8_t *data, uint8_t num)
 {
 	Wire.beginTransmission(i2c);
 	Wire.write(addr);
 	if (Wire.endTransmission(false) != 0) return false;
-	Wire.requestFrom(i2c, num);
-	if (Wire.available() != num) return false;
-	while (num > 0) {
-		*data++ = Wire.read();
-		num--;
-	}
-	return true;
-}
-
-static bool read_regs(uint8_t i2c, uint8_t *data, uint8_t num)
-{
 	Wire.requestFrom(i2c, num);
 	if (Wire.available() != num) return false;
 	while (num > 0) {
@@ -225,37 +229,181 @@ bool NXPMotionSense::MPL3115_begin() // pressure
 	return true;
 }
 
-bool NXPMotionSense::MPL3115_read(int32_t *altitude, int16_t *temperature)
-{
-	static elapsedMicros usec_since;
-	static int32_t usec_history=980000;
-	const uint8_t i2c_addr=MPL3115_I2C_ADDR;
-	uint8_t buf[6];
-
-	int32_t usec = usec_since;
-	if (usec + 500 < usec_history) return false;
-
-	if (!read_regs(i2c_addr, FXAS21002_STATUS, buf, 1)) return false;
-	if (buf[0] == 0) return false;
-
-	if (!read_regs(i2c_addr, buf, 6)) return false;
-
-	usec_since -= usec;
-	int diff = (usec - usec_history) >> 3;
-	if (diff < -1000) diff = -1000;
-	else if (diff > 1000) diff = 1000;
-	usec_history += diff;
-
-	int32_t a = ((uint32_t)buf[1] << 12) | ((uint16_t)buf[2] << 4) | (buf[3] >> 4);
-	if (a & 0x00080000) a |= 0xFFF00000;
-	*altitude = a;
-	*temperature = (int16_t)((buf[4] << 8) | buf[5]);
-
-	//Serial.printf("%02X %d %d: ", buf[0], usec, usec_history);
-	//Serial.printf("%6d,%6d", a, *temperature);
-	//Serial.println();
-	return true;
+void NXPMotionSense::readAltitude() //simplest way to get altitude
+{  
+  	// but slower. Does nothing while waiting for results from toggleOneShot readings from baro
+  	MPL3115_toggleOneShot();  //starts altitude calcs on baro
+  	readOneShotAlt();	    //gets alt and temperature results from baro
 }
+
+void NXPMotionSense::readOneShotAlt() //gets alt and temp results from baro
+{ 
+  	//after readAltitude()
+  	// or can be used after MPL3115_toggleOneShot() has been called for in your .ino
+
+  	uint8_t rawData[5]; // msb/csb/lsb pressure and msb/lsb temperature stored in
+                      // five contiguous registers
+  	// when below == 1: A new set of data is ready
+  	while ((read_reg(MPL3115_I2C_ADDR, MPL3115_STATUS) & 0x08) == 0);
+
+
+  	read_regs(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB, &rawData[0],
+            5); // Read the five raw data registers into data array
+
+  	// Altutude bytes-whole altitude contained defined by msb, csb, and first two
+  	// bits of lsb, fraction by next two bits of lsb
+  	uint8_t msbA = rawData[0];
+  	uint8_t csbA = rawData[1];
+  	uint8_t lsbA = rawData[2];
+  	// Temperature bytes
+  	uint8_t msbT = rawData[3];
+  	uint8_t lsbT = rawData[4];
+
+  	// Calculate altitude, check for negative sign in altimeter data
+  	long foo = 0;
+  	if (msbA > 0x7F) {
+  	  foo = ~((long)msbA << 16 | (long)csbA << 8 | (long)lsbA) +
+            	1; // 2's complement the data
+    	  altitudeM =
+        	(float)(foo >> 8) +
+        	(float)((lsbA >> 4) / 16.0); // Whole number plus fraction altitude in
+                                     // meters for negative altitude
+    	  altitudeM *= -1.;
+  	} else {
+    	  altitudeM = (float)((msbA << 8) | csbA) +
+                (float)((lsbA >> 4) /
+                        16.0); // Whole number plus fraction altitude in meters
+  	}
+
+  	// Calculate temperature, check for negative sign
+  	if (msbT > 0x7F) {
+    		foo = ~(msbT << 8 | lsbT) + 1; // 2's complement
+    		temperatureC = (float)(foo >> 8) +
+                   (float)((lsbT >> 4) /
+                           16.0); // add whole and fractional degrees Centigrade
+    		temperatureC *= -1.;
+  	} else {
+    		temperatureC = (float)(msbT) +
+                   (float)((lsbT >> 4) /
+                           16.0); // add whole and fractional degrees Centigrade
+  	}
+}
+
+void NXPMotionSense::readPressure() {
+  	const uint8_t i2c_addr = MPL3115_I2C_ADDR;
+
+  	// switch to pressure mode
+  	//  place into standby mode
+  	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0);
+  	// switch to active, altimeter mode, 32 ms measurement, polling mode
+  	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0x29);
+  	// enable events
+  	write_reg(i2c_addr, MPL3115_PT_DATA_CFG, 0x07);
+
+  	byte rawData[5]; // msb/csb/lsb pressure and msb/lsb temperature stored in
+                   // five contiguous registers
+
+  	while ((read_reg(MPL3115_I2C_ADDR, MPL3115_STATUS) & 0x08) == 0);
+  	MPL3115_toggleOneShot();
+
+  	read_regs(MPL3115_I2C_ADDR, MPL3115_OUT_P_MSB, &rawData[0],
+            5); // Read the five raw data registers into data array
+
+  	// Pressure bytes
+  	uint8_t msbP = rawData[0];
+  	uint8_t csbP = rawData[1];
+  	uint8_t lsbP = rawData[2];
+  	// Temperature bytes
+  	uint8_t msbT = rawData[3];
+  	uint8_t lsbT = rawData[4];
+
+  	long pressure_whole = ((long)msbP << 16 | (long)csbP << 8 |
+        	(long)lsbP); // Construct whole number pressure
+  	pressure_whole >>= 6; // Only two most significant bits of lsbP contribute to
+                        // whole pressure; its an 18-bit number
+
+  	lsbP &= 0x30; // Keep only bits 5 and 6, the fractional pressure
+  	lsbP >>= 4; // Shift to get the fractional pressure in terms of quarters of a
+              // Pascal
+  	float pressure_frac =
+      		(float)lsbP / 4.0; // Convert numbers of fractional quarters to fractional
+                         // pressure n Pasacl
+
+  	pressure = (float)(pressure_whole) +
+        	pressure_frac; // Combine whole and fractional parts to get entire
+                            // pressure in Pascal
+  	pressure = pressure / 100.0f;
+
+  	// Calculate temperature, check for negative sign
+  	long foo = 0;
+  	if (msbT > 0x7F) {
+  		foo = ~(msbT << 8 | lsbT) + 1; // 2's complement
+    	temperatureC = (float)(foo >> 8) +
+        	(float)((lsbT >> 4) /
+                	16.0); // add whole and fractional degrees Centigrade
+    	temperatureC *= -1.;
+  	} else {
+    		temperatureC = (float)(msbT) +
+                	(float)((lsbT >> 4) /
+                        	16.0); // add whole and fractional degrees Centigrade
+  	}
+
+  	// switch back to altimeter mode
+  	//  place into standby mode
+  	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0);
+  	// switch to active, altimeter mode, 10 ms measurement, polling mode
+  	write_reg(i2c_addr, MPL3115_CTRL_REG1, 0x89);
+  	// enable events
+  	write_reg(i2c_addr, MPL3115_PT_DATA_CFG, 0x07);
+}
+
+	/*!
+	 *  @brief Set the oversample rate
+	 *  @param sampleRate oversample rate from 0 to 7
+	 * The higher the oversample rate the more time between samples
+	 */
+void NXPMotionSense::setOversampleRate(int8_t sampleRate) 
+{
+	if (sampleRate > 7)
+	sampleRate = 7; // OS cannot be larger than 0b.0111
+	sampleRate <<= 3; // Align it for the CTRL_REG1 register
+
+  	int8_t tempSetting =
+	read_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1); // Read current settings
+	tempSetting &= 0xc7;       // B11000111; //Clear out old OS bits
+	tempSetting |= sampleRate; // Mask in new OS bits
+	write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, tempSetting);
+}
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+// Clears then sets OST bit which causes the sensor to immediately take another
+// reading
+void NXPMotionSense::MPL3115_toggleOneShot() 
+{
+  	// MPL3115_Active();  // Set to active to start reading
+  	byte c;
+  	read_regs(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, &c, 1);
+  	write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1,
+            c & ~(1 << 1)); // Clear OST (bit 1)
+  	read_regs(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1, &c, 1);
+  	write_reg(MPL3115_I2C_ADDR, MPL3115_CTRL_REG1,
+            c | (1 << 1)); // Set OST bit to 1
+}
+
+	/*!
+	 *  @brief  Set the local sea level barometric pressure
+	 *  @param pascal the pressure to use as the baseline
+	 */
+
+void NXPMotionSense::setSeaPressure(float pascal) 
+{
+  	uint16_t bar = pascal / 2;
+  	Wire.beginTransmission(MPL3115_I2C_ADDR);
+  	Wire.write((uint8_t)MPL3115_BAR_IN_MSB);
+  	Wire.write((uint8_t)(bar >> 8));
+  	Wire.write((uint8_t)bar);
+  	Wire.endTransmission(false);
+}	
 
 bool NXPMotionSense::writeCalibration(const void *data)
 {

--- a/NXPMotionSense.h
+++ b/NXPMotionSense.h
@@ -92,7 +92,7 @@ public:
 	void readAltitude();
 	void MPL3115_toggleOneShot();
 	void readOneShotAlt();
-	void setOversampleRate();
+	void setOversampleRate(int8_t sampleRate);
 	float altitudeM, temperatureC, pressure;
 	
 private:

--- a/NXPMotionSense.h
+++ b/NXPMotionSense.h
@@ -86,6 +86,15 @@ public:
 		}
 		if (fieldstrength != NULL) *fieldstrength = cal[9];
 	}
+	
+	void setSeaPressure(float pascal);
+	void readPressure();
+	void readAltitude();
+	void MPL3115_toggleOneShot();
+	void readOneShotAlt();
+	void setOversampleRate();
+	float altitudeM, temperatureC, pressure;
+	
 private:
 	void update();
 	bool FXOS8700_begin();
@@ -122,6 +131,10 @@ public:
 		quat[2] = qPl.q2;
 		quat[3] = qPl.q3;
 	}
+	
+	float getHeading() { return RhoPl; } // compass deg
+	float getTilt() { return ChiPl; }    // tilt from vertical
+	
 	// These are Madgwick & Mahony - extrinsic rotation reference (wrong!)
 	//float getPitch() {return atan2f(2.0f * qPl.q2 * qPl.q3 - 2.0f * qPl.q0 * qPl.q1, 2.0f * qPl.q0 * qPl.q0 + 2.0f * qPl.q3 * qPl.q3 - 1.0f);};
 	//float getRoll() {return -1.0f * asinf(2.0f * qPl.q1 * qPl.q3 + 2.0f * qPl.q0 * qPl.q2);};

--- a/NXPMotionSense.h
+++ b/NXPMotionSense.h
@@ -86,6 +86,15 @@ public:
 		}
 		if (fieldstrength != NULL) *fieldstrength = cal[9];
 	}
+	
+	void setSeaPressure(float pascal);
+	void readPressure();
+	void readAltitude();
+	void MPL3115_toggleOneShot();
+	void readOneShotAlt();
+	void setOversampleRate(int8_t sampleRate);
+	float altitudeM, temperatureC, pressure;
+	
 private:
 	void update();
 	bool FXOS8700_begin();
@@ -122,6 +131,10 @@ public:
 		quat[2] = qPl.q2;
 		quat[3] = qPl.q3;
 	}
+	
+	float getHeading() { return RhoPl; } // compass deg
+	float getTilt() { return ChiPl; }    // tilt from vertical
+	
 	// These are Madgwick & Mahony - extrinsic rotation reference (wrong!)
 	//float getPitch() {return atan2f(2.0f * qPl.q2 * qPl.q3 - 2.0f * qPl.q0 * qPl.q1, 2.0f * qPl.q0 * qPl.q0 + 2.0f * qPl.q3 * qPl.q3 - 1.0f);};
 	//float getRoll() {return -1.0f * asinf(2.0f * qPl.q1 * qPl.q3 + 2.0f * qPl.q0 * qPl.q2);};

--- a/RocketVisualizer/RocketVisualizer.pde
+++ b/RocketVisualizer/RocketVisualizer.pde
@@ -1,0 +1,297 @@
+//  This software is based on Paul Stoffregen's work 
+//  It was adapted to display a 3D rocket with position, altitude and GPS information
+//  And to work through serial radio modems from Digi
+//  More info about project: https://hackaday.io/project/15425-rocket-real-time-transponder-and-gui
+
+import processing.serial.*;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+Serial myPort;
+
+//  Define file for storing received information. This is a time and date stamped filename.
+String outFilename = month()+ "-" + day() + "-" + year() + "_" + hour() + "_" + minute() + "-" + "data.csv";
+//Serial myPort;  //only one serial port in use here. This is connected to an XBee Pro device
+
+float yaw = 0.0;
+float pitch = 0.0;
+float roll = 0.0;
+float altitude = 0.0;
+float fLon = 0.0;
+float fLat =0.0;
+long lon = 0;
+long lat = 0;
+
+
+void setup()
+{
+  size(900, 900, P3D);
+  // if you have only ONE serial port active
+  myPort = new Serial(this, "/dev/ttyACM0", 9600);   // Linux "/dev/ttyACM#"
+  //myPort = new Serial(this, Serial.list()[0], 230400); // if you have only ONE serial port active 
+  //XBees need to be programmed with the above baud setting. XBee Pro S1 max 115200
+  //XBee pro SC2 max at 230400 baud. Need to make sure firmware in xbee is set to 802.15.4 TH PRO setting
+  // if you know the serial port name
+  //myPort = new Serial(this, "COM6:", 230400);        // Windows "COM#:"
+  //myPort = new Serial(this, "\\\\.\\COM41", 9600); // Windows, COM10 or higher
+  //myPort = new Serial(this, "/dev/ttyACM0", 9600);   // Linux "/dev/ttyACM#"
+  //myPort = new Serial(this, "/dev/cu.usbmodem1217321", 9600);  // Mac "/dev/cu.usbmodem######"
+  textSize(16); // set text size
+  textMode(SHAPE); // set text mode to shape
+}
+
+void draw()
+{
+  serialEvent();  // read and parse incoming serial message
+  background(255); // set background to white
+  lights();
+  translate(width/2, height/2); // set position to centre
+  pushMatrix(); // begin object
+  float c1 = cos(radians(-roll));
+  float s1 = sin(radians(-roll));
+  float c2 = cos(radians(-pitch));
+  float s2 = sin(radians(-pitch));
+  float c3 = cos(radians(yaw));
+  float s3 = sin(radians(yaw));
+  applyMatrix( c2*c3, s1*s3+c1*c3*s2, c3*s1*s2-c1*s3, 0,
+               -s2, c1*c2, c2*s1, 0,
+               c2*s3, c1*s2*s3-c3*s1, c1*c3+s1*s2*s3, 0,
+               0, 0, 0, 1);
+
+  //drawPropShield();  //we are going to draw a rocket instead
+
+  drawRocket();
+  popMatrix(); // end of object
+  //Print variable values to the bottom of window
+  text("ALTITUDE",-400,400);//heading
+  text(round(altitude),-400,420);
+  text(" ROLL",-300,400);  //heading
+  text(roll,-300,420);     //print variable  
+  text(" PITCH",-200,400);
+  text(pitch,-200,420);
+  text(" YAW",-100,400);
+  text(yaw,-100,420); //was 360-yaw,
+  //text(" LAT",0,400);
+  //text(nf(fLat,2,5),0,420);
+  //text(" LON",100,400);
+  //text(nf(fLon,3,5),100,420);
+  
+  // Print values to console
+  print(roll);
+  print("\t");
+  print(pitch);
+  print("\t");
+  print(yaw);  //was 360-yaw
+  println();
+}
+
+
+void drawRocket()
+{
+    background(0, 128, 255);
+    lights();
+    fill(255,0,0);
+    rotateY(PI/2);
+    pushMatrix();
+    drawCylinder( 30, 50, 50, 500);
+    popMatrix();
+    pushMatrix();    
+    translate( 0, 0, -325);
+    fill(0);
+    drawCylinder( 30, 0, 50, 150 );
+    popMatrix();
+
+beginShape();
+//start rocket fin set
+  fill(255,255,255);
+  translate( 0, 0, 100 );
+  rotateY(PI);
+  //rotateZ(PI/3);
+  vertex(-100, 0, -150);
+  vertex( 100, 0, -150);
+  vertex(   0,    0,  100);
+endShape();
+
+//start another rocket fin set
+  fill(0);
+  translate( 0, 0, -150 );
+  beginShape();
+  vertex( 0, 100, 0);
+  vertex( 0,  -100, 0);
+  vertex(   0,    0,  250);
+endShape();
+
+}
+
+void drawCylinder( int sides, float r1, float r2, float h)
+{
+    float angle = 360 / sides;
+    float halfHeight = h / 2;
+
+    // draw top of the tube
+    beginShape();
+    for (int i = 0; i < sides; i++) {
+        float x = cos( radians( i * angle ) ) * r1;
+        float y = sin( radians( i * angle ) ) * r1;
+        vertex( x, y, -halfHeight);
+    }
+    endShape(CLOSE);
+
+    // draw bottom of the tube
+    beginShape();
+    for (int i = 0; i < sides; i++) {
+        float x = cos( radians( i * angle ) ) * r2;
+        float y = sin( radians( i * angle ) ) * r2;
+        vertex( x, y, halfHeight);
+    }
+    endShape(CLOSE);
+    
+    // fill sides
+    beginShape(TRIANGLE_STRIP);
+    stroke(180,0,0);
+    for (int i = 0; i < sides + 1; i++) {
+        float x1 = cos( radians( i * angle ) ) * r1;
+        float y1 = sin( radians( i * angle ) ) * r1;
+        float x2 = cos( radians( i * angle ) ) * r2;
+        float y2 = sin( radians( i * angle ) ) * r2;
+        vertex( x1, y1, -halfHeight);
+        vertex( x2, y2, halfHeight);    
+    }
+    endShape(CLOSE);
+}
+
+void serialEvent()
+{
+  int newLine = 13; // new line character in ASCII
+  String message;
+  do {
+    message = myPort.readStringUntil(newLine); // read from port until new line
+    if (message != null) {
+      String[] list = split(trim(message), " ");
+      if (list.length >= 4 && list[0].equals("Orientation:")) {  
+        yaw = float(list[1]); // convert to float yaw
+        pitch = float(list[2]); // convert to float pitch
+        roll = float(list[3]); // convert to float roll
+        altitude = float(list[4]); // convert to float alt (altitude)
+//        fLat = float(list[5])/1000000; //lattitude is received without a decimal point, although the math done by the arduino converts it to decimal form
+//        fLon = float(list[6])/1000000; // This divide function gets our decimal point back
+        // Write received values to the text file
+        //appendTextToFile(outFilename, millis() + ", " + list[0] + ", " + list[1] + ", " + list[2] + ", " + list[3] + ", " +list[4] + ", " + list[5] + ", " +list[6] + ", " + second()); //print out to file just altitude
+        appendTextToFile(outFilename, millis() + ", " + list[0] + ", " + list[1] + ", " + list[2] + ", " + list[3] + ", " +list[4] + ", " + second()); //print out to file just altitude
+      }
+    }
+  } while (message != null);
+}
+
+
+
+void drawPropShield()   // function not being used or displayed here
+{
+  // 3D art by Benjamin Rheinland
+  stroke(0); // black outline
+  fill(0, 128, 0); // fill color PCB green
+  box(190, 6, 70); // PCB base shape
+
+  fill(255, 215, 0); // gold color
+  noStroke();
+
+  //draw 14 contacts on Y- side
+  translate(65, 0, 30);
+  for (int i=0; i<14; i++) {
+    sphere(4.5); // draw gold contacts
+    translate(-10, 0, 0); // set new position
+  }
+
+  //draw 14 contacts on Y+ side
+  translate(10, 0, -60);
+  for (int i=0; i<14; i++) {
+    sphere(4.5); // draw gold contacts
+    translate(10, 0, 0); // set position
+  }
+
+  //draw 5 contacts on X+ side (DAC, 3v3, gnd)
+  translate(-10,0,10);
+  for (int i=0; i<5; i++) {
+    sphere(4.5);
+    translate(0,0,10);
+  }
+
+  //draw 4 contacts on X+ side (G C D 5)
+  translate(25,0,-15);
+  for (int i=0; i<4; i++) {
+    sphere(4.5);
+    translate(0,0,-10);
+  }
+
+  //draw 4 contacts on X- side (5V - + GND)
+  translate(-180,0,10);
+  for (int i=0; i<4; i++) {
+    sphere(4.5);
+    translate(0,0,10);
+  }
+
+  //draw audio amp IC
+  stroke(128);
+  fill(24);    //Epoxy color
+  translate(30,-6,-25);
+  box(13,6,13);
+
+  //draw pressure sensor IC
+  stroke(64);
+  translate(32,0,0);
+  fill(192);
+  box(10,6,18);
+
+  //draw gyroscope IC
+  stroke(128);
+  translate(27,0,0);
+  fill(24);
+  box(16,6,16);
+
+  //draw flash memory IC
+  translate(40,0,-15);
+  box(20,6,20);
+
+  //draw accelerometer/magnetometer IC
+  translate(-5,0,25);
+  box(12,6,12);
+
+  //draw 5V level shifter ICs
+  translate(42.5,2,0);
+  box(6,4,8);
+  translate(0,0,-20);
+  box(6,4,8);
+}
+
+
+/**
+ * Appends text to the end of a text file located in the data directory, 
+ * creates the file if it does not exist.
+ * Can be used for big files with lots of rows, 
+ * existing lines will not be rewritten
+ */
+void appendTextToFile(String filename, String text){
+  File f = new File(dataPath(filename));
+  if(!f.exists()){
+    createFile(f);
+  }
+  try {
+    PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(f, true)));
+    out.println(text);
+    out.close();
+  }catch (IOException e){
+      e.printStackTrace();
+  }
+}
+
+/**
+ * Creates a new file including all subfolders
+ */
+void createFile(File f){
+  File parentDir = f.getParentFile();
+  try{
+    parentDir.mkdirs(); 
+    f.createNewFile();
+  }catch(Exception e){
+    e.printStackTrace();
+  }
+}  

--- a/examples/Attitude-AltitudeData2/Attitude-AltitudeData2.ino
+++ b/examples/Attitude-AltitudeData2/Attitude-AltitudeData2.ino
@@ -1,0 +1,94 @@
+// Full orientation sensing using NXP's advanced sensor fusion algorithm.
+// toggleOneShot has been added to the NXPMotionSense.cpp so that you can start a altitude conversion
+// on the MPLX3115, and then do other things like read all the 9dof data and calculate their fusion
+// By the time you readOneShotAlt , the conversion is complete. 
+
+// You *must* perform a magnetic calibration before this code will work.
+//
+// To view this data, use the Arduino Serial Monitor to watch the
+// scrolling angles, or run the OrientationVisualiser example in Processing.
+
+#include "NXPMotionSense.h"
+#include <Wire.h>
+#include <EEPROM.h>
+#include "kalman.h"         // https://www.andico.org/2013/06/1-dimensional-kalman-filter-arduino.html?m=1
+#include <CircularBuffer.h> // https://github.com/rlogiacco/CircularBuffer
+
+KalmanFilter kf(0, .008, 10); // This is for kalman altimeter filter tuning ... was (0, .01, 1.0)
+NXPMotionSense imu;
+NXPSensorFusion filter;
+float minAlt = 32767;      // zero minAlt and avg, but max out minimum, so that it gives true minimum
+float maxAlt = 0;          // zero maxAlt
+elapsedMillis MPL = 0;
+elapsedMicros MPLm = 0;
+CircularBuffer<float, 20> buffer;  // setup a circular buffer that holds 20 values
+// if you change the sampleHertz away from 10hz, your circular buffer will not hold 1 second worth of data 
+
+void setup() {
+  Serial.begin(9600);
+  imu.begin();
+  filter.begin(100); // Normal rate is 100 hertz for gathering and computing SensorFusion from the IMU
+  imu.setOversampleRate(1); //MPL3115 sample rate of 2 keeps up with 200 hertz reads on a Teensy 4.0
+
+  //sets local sea level pressure
+  //you can get this from your closest airport from
+  //     https://aviationweather.gov/metar
+  imu.setSeaPressure(102450); // value of 101940 = 1019.40 bar
+}
+
+void loop() {
+  MPLm = 0;
+  imu.MPL3115_toggleOneShot(); //tells MPL3115 to start gathering altitude and temperature data
+  // Do other things while MPL3115 works on altitude and temperature data
+  float ax, ay, az;
+  float gx, gy, gz;
+  float mx, my, mz;
+  float roll, pitch, heading;
+
+  if (imu.available()) {
+    // Read the motion sensors
+    imu.readMotionSensor(ax, ay, az, gx, gy, gz, mx, my, mz);
+    // Update the SensorFusion filter
+    filter.update(gx, gy, gz, ax, ay, az, mx, my, mz);
+
+    // print the heading, pitch and roll
+    roll = filter.getRoll();
+    pitch = filter.getPitch();
+    heading = filter.getYaw();
+    heading = 360-heading;
+    if (heading <=180) {  // correct heading direction
+      heading = heading +180;
+    } else {
+      heading = heading - 180;
+    } 
+    Serial.print("Orientation: ");
+    Serial.print(heading);
+    Serial.print(" ");
+    Serial.print(pitch);
+    Serial.print(" ");
+    Serial.print(-roll); //correct roll direction with -
+    Serial.print(" ");
+
+    imu.readOneShotAlt();
+    //Serial.printf("Alt: %f, TempC: %f\n", imu.altitudeM, imu.temperatureC);
+    float alt_kalman = kf.step(imu.altitudeM); //filter noise from altimeter sensor, and get readings to settle
+    
+    //Circular buffer part from https://github.com/rlogiacco/CircularBuffer/tree/master/examples/CircularBuffer 
+    //I have it set for holding the last 20 readings and then we calulate maxAlt, minAlt and avg
+    //in the buffer after each new reading is taken. Oldest readings are discarded each time a new one is pushed 
+    buffer.push(alt_kalman); // Place new kalman filtered reading in altitude buffer
+		float avg = 0;
+	  using index_t = decltype(buffer)::index_t; // sets up circularbuffer
+    for (index_t i = 0; i < buffer.size(); i++) {
+			avg += buffer[i]; 
+      if (buffer[i] > maxAlt) maxAlt = buffer[i];
+      if (buffer[i] < minAlt) minAlt = buffer[i];
+		}
+    avg = avg / buffer.size(); //calculates new average each time a new reading is taken
+    Serial.print(avg);
+    Serial.print(" ");
+    Serial.println(MPLm);
+    //imu.readAltitude();
+    //imu.readPressure();
+  }
+}

--- a/kalman.cpp
+++ b/kalman.cpp
@@ -1,0 +1,35 @@
+#include "kalman.h"
+
+KalmanFilter::KalmanFilter(float estimate, float initQ, float initR)
+{
+  Q = initQ;
+  R = initR;
+
+  // initial values for the kalman filter
+  x_est_last = 0;
+  P_last = 0;
+
+  // initialize with a measurement
+  x_est_last = estimate;
+}
+
+// add a new measurement, return the Kalman-filtered value
+float KalmanFilter::step(float z_measured)
+{
+  // do a prediction
+  x_temp_est = x_est_last;
+  P_temp = P_last + R*Q;
+
+  // calculate the Kalman gain
+  K = P_temp * (1.0/(P_temp + R));
+
+  // correct
+  x_est = x_temp_est + K * (z_measured - x_temp_est); 
+  P = (1- K) * P_temp;
+
+  // update our last's
+  P_last = P;
+  x_est_last = x_est;
+
+  return (x_est);
+}

--- a/kalman.h
+++ b/kalman.h
@@ -1,0 +1,20 @@
+class KalmanFilter
+{
+public:
+  KalmanFilter(float estimate, float initQ, float initR);
+  float step(float measurement);
+private:
+  // initial values for the kalman filter
+  float x_est_last;
+  float P_last;
+
+  // the noise in the system
+  float Q;
+  float R;
+
+  float K;    // Kalman gain
+  float P;
+  float P_temp;
+  float x_temp_est;
+  float x_est;
+};

--- a/utility/NXPSensorRegisters.h
+++ b/utility/NXPSensorRegisters.h
@@ -145,7 +145,7 @@
 
 #define MPL3115_I2C_ADDR             0x60 // fixed I2C address
 #define MPL3115_STATUS               0x00 // Sensor Status Register
-#define MPL3115_OUT P_MSB            0x01 // Pressure Data Out MSB
+#define MPL3115_OUT_P_MSB            0x01 // Pressure Data Out MSB
 #define MPL3115_OUT_P_CSB            0x02 // Pressure Data Out CSB
 #define MPL3115_OUT_P_LSB            0x03 // Pressure Data Out LSB
 #define MPL3115_OUT_T_MSB            0x04 // Temperature Data Out MSB

--- a/utility/NXPSensorRegisters.h
+++ b/utility/NXPSensorRegisters.h
@@ -151,7 +151,7 @@
 #define MPL3115_OUT_T_MSB            0x04 // Temperature Data Out MSB
 #define MPL3115_OUT_T_LSB            0x05 // Temperature Data Out LSB
 #define MPL3115_DR_STATUS            0x06 // Sensor Status Register
-#define MPL3115_OUT_P_DELTA MSB      0x07 // Pressure Data Out Delta MSB
+#define MPL3115_OUT_P_DELTA_MSB      0x07 // Pressure Data Out Delta MSB
 #define MPL3115_OUT_P_DELTA_CSB      0x08 // Pressure Data Out Delta CSB
 #define MPL3115_OUT_P_DELTA_LSB      0x09 // Pressure Data Out Delta LSB
 #define MPL3115_OUT_T_DELTA_MSB      0x0A // Temperature Data Out Delta MSB

--- a/utility/NXPSensorRegisters.h
+++ b/utility/NXPSensorRegisters.h
@@ -123,7 +123,7 @@
 #define FXAS21002_STATUS             0x00 // Alias for DR_STATUS or F_STATUS
 #define FXAS21002_OUT_X_MSB          0x01 // MSB of 16 bit X-axis data sample
 #define FXAS21002_OUT_X_LSB          0x02 // LSB of 16 bit X-axis data sample
-#define FXAS21002_OUT_Y _MSB         0x03 // MSB of 16 bit Y-axis data sample
+#define FXAS21002_OUT_Y_MSB          0x03 // MSB of 16 bit Y-axis data sample
 #define FXAS21002_OUT_Y_LSB          0x04 // LSB of 16 bit Y-axis data sample
 #define FXAS21002_OUT_Z_MSB          0x05 // MSB of 16 bit Z-axis data sample
 #define FXAS21002_OUT_Z_LSB          0x06 // LSB of 16 bit Z-axis data sample

--- a/utility/NXPSensorRegisters.h
+++ b/utility/NXPSensorRegisters.h
@@ -123,7 +123,7 @@
 #define FXAS21002_STATUS             0x00 // Alias for DR_STATUS or F_STATUS
 #define FXAS21002_OUT_X_MSB          0x01 // MSB of 16 bit X-axis data sample
 #define FXAS21002_OUT_X_LSB          0x02 // LSB of 16 bit X-axis data sample
-#define FXAS21002_OUT_Y _MSB         0x03 // MSB of 16 bit Y-axis data sample
+#define FXAS21002_OUT_Y_MSB          0x03 // MSB of 16 bit Y-axis data sample
 #define FXAS21002_OUT_Y_LSB          0x04 // LSB of 16 bit Y-axis data sample
 #define FXAS21002_OUT_Z_MSB          0x05 // MSB of 16 bit Z-axis data sample
 #define FXAS21002_OUT_Z_LSB          0x06 // LSB of 16 bit Z-axis data sample
@@ -145,13 +145,13 @@
 
 #define MPL3115_I2C_ADDR             0x60 // fixed I2C address
 #define MPL3115_STATUS               0x00 // Sensor Status Register
-#define MPL3115_OUT P_MSB            0x01 // Pressure Data Out MSB
+#define MPL3115_OUT_P_MSB            0x01 // Pressure Data Out MSB
 #define MPL3115_OUT_P_CSB            0x02 // Pressure Data Out CSB
 #define MPL3115_OUT_P_LSB            0x03 // Pressure Data Out LSB
 #define MPL3115_OUT_T_MSB            0x04 // Temperature Data Out MSB
 #define MPL3115_OUT_T_LSB            0x05 // Temperature Data Out LSB
 #define MPL3115_DR_STATUS            0x06 // Sensor Status Register
-#define MPL3115_OUT_P_DELTA MSB      0x07 // Pressure Data Out Delta MSB
+#define MPL3115_OUT_P_DELTA_MSB      0x07 // Pressure Data Out Delta MSB
 #define MPL3115_OUT_P_DELTA_CSB      0x08 // Pressure Data Out Delta CSB
 #define MPL3115_OUT_P_DELTA_LSB      0x09 // Pressure Data Out Delta LSB
 #define MPL3115_OUT_T_DELTA_MSB      0x0A // Temperature Data Out Delta MSB


### PR DESCRIPTION
This adds some changes to allow for much faster barometer reads (from inside NXPMotionSense), to set local barometer pressure for more accurate altitude calcs, and kalman as well as circular buffer filtering to smooth out altitude results. An example Attitude_AltitudeData2.ino was added to show the use some of the new functions. And a new rocket .pde visualization example was added. Some of these changes came from https://github.com/mjs513/NXPMotionSense 